### PR TITLE
wrong remainder/modulo usage caused malfunction when maxValue-minValu…

### DIFF
--- a/meternumberpicker/src/main/java/com/alexzaitsev/meternumberpicker/MeterNumberPicker.java
+++ b/meternumberpicker/src/main/java/com/alexzaitsev/meternumberpicker/MeterNumberPicker.java
@@ -423,13 +423,14 @@ public class MeterNumberPicker extends View {
     // =============================================================================================
 
     private int getValue(int offset) {
-        offset %= maxValue - minValue;
-        if (value + offset < minValue) {
-            return maxValue - (Math.abs(offset) - (value - minValue)) + 1;
-        } else if (value + offset > maxValue) {
-            return minValue + offset - (maxValue - value) - 1;
+	int distance = maxValue-minValue+1;
+	int result = value + offset % distance;
+        if (result < minValue) {
+            return result + distance;
+        } else if (result > maxValue) {
+            return result - distance;
         }
-        return value + offset;
+        return result;
     }
 
     private String formatNumberWithLocale(int value) {


### PR DESCRIPTION
Use of a MeterNumberPicker with (minValue=0, maxValue=1) failed: number was never changing.
Reason was a faulty use of the remainder (%) operator, in this case leading to (offset%1) which is always 0. 
I changed (and by the way simplified) the function, which should now work in all situations.
Nevertheless: great work :-))
here's a snippet of the new code (changed from line 425 on):

```
    private int getValue(int offset) {
	int distance = maxValue-minValue+1;
	int result = value + offset % distance;
        if (result < minValue) {
            return result + distance;
        } else if (result > maxValue) {
            return result - distance;
        }
        return result;
    }

```
